### PR TITLE
Setting SELinux to enforcing & adding androidboot.verifiedbootstate=green

### DIFF
--- a/arch/arm/configs/kminilte_00_defconfig
+++ b/arch/arm/configs/kminilte_00_defconfig
@@ -666,7 +666,7 @@ CONFIG_ARM_FLUSH_CONSOLE_ON_RESTART=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0
 CONFIG_ZBOOT_ROM_BSS=0
-CONFIG_CMDLINE="androidboot.baseband=exynos3470 androidboot.selinux=enforcing androidboot.hardware=universal3470"
+CONFIG_CMDLINE="androidboot.baseband=exynos3470 androidboot.selinux=enforcing androidboot.hardware=universal3470 androidboot.verifiedbootstate=green"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/kminilte_00_defconfig
+++ b/arch/arm/configs/kminilte_00_defconfig
@@ -666,7 +666,7 @@ CONFIG_ARM_FLUSH_CONSOLE_ON_RESTART=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0
 CONFIG_ZBOOT_ROM_BSS=0
-CONFIG_CMDLINE="androidboot.baseband=exynos3470 androidboot.selinux=permissive androidboot.hardware=universal3470"
+CONFIG_CMDLINE="androidboot.baseband=exynos3470 androidboot.selinux=enforcing androidboot.hardware=universal3470"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -2,10 +2,13 @@
 #include <linux/init.h>
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
+#include <asm/setup.h>
+
+static char proc_cmdline[COMMAND_LINE_SIZE];
 
 static int cmdline_proc_show(struct seq_file *m, void *v)
 {
-	seq_printf(m, "%s\n", saved_command_line);
+	seq_printf(m, "%s\n", proc_cmdline);
 	return 0;
 }
 
@@ -23,6 +26,23 @@ static const struct file_operations cmdline_proc_fops = {
 
 static int __init proc_cmdline_init(void)
 {
+	/* SafetyNet bypass: show androidboot.verifiedbootstate=green */
+	char *a1, *a2;
+
+	a1 = strstr(saved_command_line, "androidboot.verifiedbootstate=");
+	if (a1) {
+		a1 = strchr(a1, '=');
+		a2 = strchr(a1, ' ');
+		if (!a2) /* last argument on the cmdline */
+			a2 = "";
+
+		scnprintf(proc_cmdline, COMMAND_LINE_SIZE, "%.*sgreen%s",
+			  (int)(a1 - saved_command_line + 1),
+			  saved_command_line, a2);
+	} else {
+		strncpy(proc_cmdline, saved_command_line, COMMAND_LINE_SIZE);
+	}
+
 	proc_create("cmdline", 0, NULL, &cmdline_proc_fops);
 	return 0;
 }


### PR DESCRIPTION
Android's SafetyNet checks, among other things, whether SELinux is set to enforcing and bootloader is locked. The bootloader fix is taken from https://github.com/Tortel/android_kernel_leeco_msm8996/commit/1d271a554cdc9b8427d809fbcf2b853b168d541f

For more information regarding the bootloader fix you can check https://github.com/sultanxda/android_kernel_oneplus_msm8996/commit/abc05b16bbd33521c2fffaf491c5657a94bfcfc5